### PR TITLE
Unmarshaling custom fields from "stat" packet

### DIFF
--- a/gateway/backend.go
+++ b/gateway/backend.go
@@ -393,6 +393,7 @@ func newGatewayStatsPacket(mac lorawan.EUI64, stat Stat) gw.GatewayStatsPacket {
 		Altitude:            float64(stat.Alti),
 		RXPacketsReceived:   int(stat.RXNb),
 		RXPacketsReceivedOK: int(stat.RXOK),
+		CustomData:          stat.CustomFields,
 	}
 }
 

--- a/gateway/structs.go
+++ b/gateway/structs.go
@@ -393,17 +393,20 @@ type RXPK struct {
 
 // Stat contains the status of the gateway.
 type Stat struct {
-	Time      ExpandedTime           `json:"time"` // UTC 'system' time of the gateway, ISO 8601 'expanded' format (e.g 2014-01-12 08:59:28 GMT)
-	Lati      float64                `json:"lati"` // GPS latitude of the gateway in degree (float, N is +)
-	Long      float64                `json:"long"` // GPS latitude of the gateway in degree (float, E is +)
-	Alti      int32                  `json:"alti"` // GPS altitude of the gateway in meter RX (integer)
-	RXNb      uint32                 `json:"rxnb"` // Number of radio packets received (unsigned integer)
-	RXOK      uint32                 `json:"rxok"` // Number of radio packets received with a valid PHY CRC
-	RXFW      uint32                 `json:"rxfw"` // Number of radio packets forwarded (unsigned integer)
-	ACKR      float64                `json:"ackr"` // Percentage of upstream datagrams that were acknowledged
-	DWNb      uint32                 `json:"dwnb"` // Number of downlink datagrams received (unsigned integer)
-	AllFields map[string]interface{} `json:"-"`    // All fields (including custom fields) are unmarshaled here
+	Time         ExpandedTime           `json:"time"` // UTC 'system' time of the gateway, ISO 8601 'expanded' format (e.g 2014-01-12 08:59:28 GMT)
+	Lati         float64                `json:"lati"` // GPS latitude of the gateway in degree (float, N is +)
+	Long         float64                `json:"long"` // GPS latitude of the gateway in degree (float, E is +)
+	Alti         int32                  `json:"alti"` // GPS altitude of the gateway in meter RX (integer)
+	RXNb         uint32                 `json:"rxnb"` // Number of radio packets received (unsigned integer)
+	RXOK         uint32                 `json:"rxok"` // Number of radio packets received with a valid PHY CRC
+	RXFW         uint32                 `json:"rxfw"` // Number of radio packets forwarded (unsigned integer)
+	ACKR         float64                `json:"ackr"` // Percentage of upstream datagrams that were acknowledged
+	DWNb         uint32                 `json:"dwnb"` // Number of downlink datagrams received (unsigned integer)
+	CustomFields map[string]interface{} `json:"-"`    // Custom fields are unmarshaled here
 }
+
+// This lists the fields of the Stat struct (to avoid slow reflection)
+var statFields = []string{"time", "lati", "long", "alti", "rxnb", "rxok", "rxfw", "ackr", "dwnb"}
 
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (s *Stat) UnmarshalJSON(b []byte) error {
@@ -412,9 +415,12 @@ func (s *Stat) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(b, &s.AllFields)
+	err = json.Unmarshal(b, &s.CustomFields)
 	if err != nil {
 		return err
+	}
+	for _, field := range statFields {
+		delete(s.CustomFields, field)
 	}
 	return nil
 }

--- a/gateway/structs.go
+++ b/gateway/structs.go
@@ -393,15 +393,30 @@ type RXPK struct {
 
 // Stat contains the status of the gateway.
 type Stat struct {
-	Time ExpandedTime `json:"time"` // UTC 'system' time of the gateway, ISO 8601 'expanded' format (e.g 2014-01-12 08:59:28 GMT)
-	Lati float64      `json:"lati"` // GPS latitude of the gateway in degree (float, N is +)
-	Long float64      `json:"long"` // GPS latitude of the gateway in degree (float, E is +)
-	Alti int32        `json:"alti"` // GPS altitude of the gateway in meter RX (integer)
-	RXNb uint32       `json:"rxnb"` // Number of radio packets received (unsigned integer)
-	RXOK uint32       `json:"rxok"` // Number of radio packets received with a valid PHY CRC
-	RXFW uint32       `json:"rxfw"` // Number of radio packets forwarded (unsigned integer)
-	ACKR float64      `json:"ackr"` // Percentage of upstream datagrams that were acknowledged
-	DWNb uint32       `json:"dwnb"` // Number of downlink datagrams received (unsigned integer)
+	Time      ExpandedTime           `json:"time"` // UTC 'system' time of the gateway, ISO 8601 'expanded' format (e.g 2014-01-12 08:59:28 GMT)
+	Lati      float64                `json:"lati"` // GPS latitude of the gateway in degree (float, N is +)
+	Long      float64                `json:"long"` // GPS latitude of the gateway in degree (float, E is +)
+	Alti      int32                  `json:"alti"` // GPS altitude of the gateway in meter RX (integer)
+	RXNb      uint32                 `json:"rxnb"` // Number of radio packets received (unsigned integer)
+	RXOK      uint32                 `json:"rxok"` // Number of radio packets received with a valid PHY CRC
+	RXFW      uint32                 `json:"rxfw"` // Number of radio packets forwarded (unsigned integer)
+	ACKR      float64                `json:"ackr"` // Percentage of upstream datagrams that were acknowledged
+	DWNb      uint32                 `json:"dwnb"` // Number of downlink datagrams received (unsigned integer)
+	AllFields map[string]interface{} `json:"-"`    // All fields (including custom fields) are unmarshaled here
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (s *Stat) UnmarshalJSON(b []byte) error {
+	type stat Stat // We don't want infinite recursion
+	err := json.Unmarshal(b, (*stat)(s))
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, &s.AllFields)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // TXPK contains a RF packet to be emitted and associated metadata.

--- a/gateway/structs_test.go
+++ b/gateway/structs_test.go
@@ -365,3 +365,18 @@ func TestTXACKPacket(t *testing.T) {
 		})
 	})
 }
+
+func TestStatUnmarshal(t *testing.T) {
+	Convey("Given a stat packet with custom data", t, func() {
+		var s Stat
+		stat := `{"rxnb":10,"mail":"some@user.domain"}`
+		Convey("Then UnmarshalJSON unmarshals the Stat packet with custom data", func() {
+			err := s.UnmarshalJSON([]byte(stat))
+			So(err, ShouldBeNil)
+			So(s.RXNb, ShouldEqual, 10)
+			So(s.AllFields, ShouldHaveLength, 2)
+			So(s.AllFields, ShouldContainKey, "mail")
+			So(s.AllFields["mail"], ShouldEqual, "some@user.domain")
+		})
+	})
+}

--- a/gateway/structs_test.go
+++ b/gateway/structs_test.go
@@ -374,9 +374,9 @@ func TestStatUnmarshal(t *testing.T) {
 			err := s.UnmarshalJSON([]byte(stat))
 			So(err, ShouldBeNil)
 			So(s.RXNb, ShouldEqual, 10)
-			So(s.AllFields, ShouldHaveLength, 2)
-			So(s.AllFields, ShouldContainKey, "mail")
-			So(s.AllFields["mail"], ShouldEqual, "some@user.domain")
+			So(s.CustomFields, ShouldHaveLength, 1)
+			So(s.CustomFields, ShouldContainKey, "mail")
+			So(s.CustomFields["mail"], ShouldEqual, "some@user.domain")
 		})
 	})
 }


### PR DESCRIPTION
This PR introduces a `map[string]interface{}` called `CustomFields` to the `Stat` packet that will contain all fields unmarshaled from the `stat` packet that are not in the `Stat` struct itself, allowing custom fields to be added to the `stat` packet without needing changes in the struct.