### PR TITLE
Care an empty string value that is contained in RXPK as `time` property

### DIFF
--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -444,8 +444,7 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 	}
 
 	if rxpk.Time != nil {
-		ts := time.Time(*rxpk.Time)
-		rxPacket.RXInfo.Time = &ts
+		rxPacket.RXInfo.Time = rxpk.Time.Time
 	}
 
 	if rxpk.Tmms != nil {

--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -443,7 +443,7 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 		},
 	}
 
-	if rxpk.Time != nil {
+	if rxpk.Time != nil && rxpk.Time.Time != nil {
 		rxPacket.RXInfo.Time = rxpk.Time.Time
 	}
 

--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -443,7 +443,7 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 		},
 	}
 
-	if rxpk.Time != nil && rxpk.Time.Time != nil {
+	if rxpk.Time != nil {
 		rxPacket.RXInfo.Time = rxpk.Time.Time
 	}
 

--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -444,7 +444,8 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 	}
 
 	if rxpk.Time != nil {
-		rxPacket.RXInfo.Time = rxpk.Time.Time
+		ts := time.Time(*rxpk.Time)
+		rxPacket.RXInfo.Time = &ts
 	}
 
 	if rxpk.Tmms != nil {

--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -445,7 +445,9 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 
 	if rxpk.Time != nil {
 		ts := time.Time(*rxpk.Time)
-		rxPacket.RXInfo.Time = &ts
+		if !ts.IsZero() {
+			rxPacket.RXInfo.Time = &ts
+		}
 	}
 
 	if rxpk.Tmms != nil {

--- a/internal/gateway/backend_test.go
+++ b/internal/gateway/backend_test.go
@@ -160,8 +160,7 @@ func TestBackend(t *testing.T) {
 				backend.skipCRCCheck = false
 
 				Convey("When sending a PUSH_DATA packet with RXPK (CRC OK + GPS timestamp)", func() {
-					utcTime := time.Now().UTC()
-					ts := CompactTime{&utcTime}
+					ts := CompactTime(time.Now().UTC())
 					tmms := int64(time.Second / time.Millisecond)
 
 					p := PushDataPacket{
@@ -262,8 +261,7 @@ func TestBackend(t *testing.T) {
 				backend.skipCRCCheck = true
 
 				Convey("When sending a PUSH_DATA packet with RXPK (CRC OK + GPS timestamp)", func() {
-					utcTime := time.Now().UTC()
-					ts := CompactTime{&utcTime}
+					ts := CompactTime(time.Now().UTC())
 					p := PushDataPacket{
 						ProtocolVersion: ProtocolVersion2,
 						RandomToken:     1234,
@@ -585,7 +583,7 @@ func TestNewTXPKFromTXPacket(t *testing.T) {
 func TestNewRXPacketFromRXPK(t *testing.T) {
 	Convey("Given a RXPK and gateway MAC", t, func() {
 		now := time.Now().UTC()
-		nowCompact := CompactTime{&now}
+		nowCompact := CompactTime(now)
 		tmms := int64(time.Second / time.Millisecond)
 		timeSinceGPSEpoch := gw.Duration(time.Second)
 

--- a/internal/gateway/backend_test.go
+++ b/internal/gateway/backend_test.go
@@ -160,7 +160,8 @@ func TestBackend(t *testing.T) {
 				backend.skipCRCCheck = false
 
 				Convey("When sending a PUSH_DATA packet with RXPK (CRC OK + GPS timestamp)", func() {
-					ts := CompactTime(time.Now().UTC())
+					utcTime := time.Now().UTC()
+					ts := CompactTime{&utcTime}
 					tmms := int64(time.Second / time.Millisecond)
 
 					p := PushDataPacket{
@@ -261,7 +262,8 @@ func TestBackend(t *testing.T) {
 				backend.skipCRCCheck = true
 
 				Convey("When sending a PUSH_DATA packet with RXPK (CRC OK + GPS timestamp)", func() {
-					ts := CompactTime(time.Now().UTC())
+					utcTime := time.Now().UTC()
+					ts := CompactTime{&utcTime}
 					p := PushDataPacket{
 						ProtocolVersion: ProtocolVersion2,
 						RandomToken:     1234,
@@ -583,7 +585,7 @@ func TestNewTXPKFromTXPacket(t *testing.T) {
 func TestNewRXPacketFromRXPK(t *testing.T) {
 	Convey("Given a RXPK and gateway MAC", t, func() {
 		now := time.Now().UTC()
-		nowCompact := CompactTime(now)
+		nowCompact := CompactTime{&now}
 		tmms := int64(time.Second / time.Millisecond)
 		timeSinceGPSEpoch := gw.Duration(time.Second)
 

--- a/internal/gateway/structs.go
+++ b/internal/gateway/structs.go
@@ -316,11 +316,19 @@ type CompactTime time.Time
 
 // MarshalJSON implements the json.Marshaler interface.
 func (t CompactTime) MarshalJSON() ([]byte, error) {
-	return []byte(time.Time(t).UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
+	t2 := time.Time(t)
+	if t2.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(t2.UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (t *CompactTime) UnmarshalJSON(data []byte) error {
+	if string(data) == `""` {
+		return nil
+	}
+
 	t2, err := time.Parse(`"`+time.RFC3339Nano+`"`, string(data))
 	if err != nil {
 		return err

--- a/internal/gateway/structs.go
+++ b/internal/gateway/structs.go
@@ -312,11 +312,11 @@ type PullRespPayload struct {
 
 // CompactTime implements time.Time but (un)marshals to and from
 // ISO 8601 'compact' format.
-type CompactTime struct{ *time.Time }
+type CompactTime time.Time
 
 // MarshalJSON implements the json.Marshaler interface.
 func (t CompactTime) MarshalJSON() ([]byte, error) {
-	return []byte(t.Time.UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
+	return []byte(time.Time(t).UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -325,7 +325,7 @@ func (t *CompactTime) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*t = CompactTime{&t2}
+	*t = CompactTime(t2)
 	return nil
 }
 

--- a/internal/gateway/structs.go
+++ b/internal/gateway/structs.go
@@ -312,11 +312,11 @@ type PullRespPayload struct {
 
 // CompactTime implements time.Time but (un)marshals to and from
 // ISO 8601 'compact' format.
-type CompactTime time.Time
+type CompactTime struct{ *time.Time }
 
 // MarshalJSON implements the json.Marshaler interface.
 func (t CompactTime) MarshalJSON() ([]byte, error) {
-	return []byte(time.Time(t).UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
+	return []byte(t.Time.UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -325,7 +325,7 @@ func (t *CompactTime) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*t = CompactTime(t2)
+	*t = CompactTime{&t2}
 	return nil
 }
 

--- a/internal/gateway/structs.go
+++ b/internal/gateway/structs.go
@@ -10,10 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"bytes"
-
 	"github.com/brocaar/lorawan"
-	log "github.com/sirupsen/logrus"
 )
 
 // PacketType defines the packet type.
@@ -38,12 +35,6 @@ const (
 // Errors
 var (
 	ErrInvalidProtocolVersion = errors.New("gateway: invalid protocol version")
-)
-
-// For RXPK JSON marshalling/unmarshalling value
-var (
-	bytesRepresentsJSONNull        = []byte("null")
-	bytesRepresentsJSONEmptyString = []byte(`""`)
 )
 
 func protocolSupported(p uint8) bool {
@@ -325,21 +316,11 @@ type CompactTime struct{ *time.Time }
 
 // MarshalJSON implements the json.Marshaler interface.
 func (t CompactTime) MarshalJSON() ([]byte, error) {
-	if t.Time == nil {
-		return bytesRepresentsJSONNull, nil
-	}
-
 	return []byte(t.Time.UTC().Format(`"` + time.RFC3339Nano + `"`)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (t *CompactTime) UnmarshalJSON(data []byte) error {
-	if bytes.Compare(data, bytesRepresentsJSONEmptyString) == 0 { // some vender's gateway sends an empty string as `time` property
-		log.Debug("Subject of CompactTime marshalling is empty")
-		*t = CompactTime{nil}
-		return nil
-	}
-
 	t2, err := time.Parse(`"`+time.RFC3339Nano+`"`, string(data))
 	if err != nil {
 		return err

--- a/internal/gateway/structs_test.go
+++ b/internal/gateway/structs_test.go
@@ -64,8 +64,7 @@ func TestCompactTime(t *testing.T) {
 
 		Convey("MarshalJSON returns '\"2006-01-02T22:04:05Z\"'", func() {
 
-			ct := CompactTime{&ts}
-			b, err := ct.MarshalJSON()
+			b, err := CompactTime(ts).MarshalJSON()
 			So(err, ShouldBeNil)
 			So(string(b), ShouldEqual, `"2006-01-02T22:04:05Z"`)
 		})
@@ -76,7 +75,7 @@ func TestCompactTime(t *testing.T) {
 				var ct CompactTime
 				err := ct.UnmarshalJSON([]byte(s))
 				So(err, ShouldBeNil)
-				So(ct.Time.Equal(ts), ShouldBeTrue)
+				So(time.Time(ct).Equal(ts), ShouldBeTrue)
 			})
 		})
 	})

--- a/internal/gateway/structs_test.go
+++ b/internal/gateway/structs_test.go
@@ -80,6 +80,22 @@ func TestCompactTime(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given an empty string as date value", t, func() {
+		Convey("MarshalJSON returns null", func() {
+			ct := CompactTime{nil}
+			b, err := ct.MarshalJSON()
+			So(err, ShouldBeNil)
+			So(string(b), ShouldEqual, "null")
+		})
+
+		Convey("UnmarshalJSON returns nil", func() {
+			var ct CompactTime
+			err := ct.UnmarshalJSON([]byte(`""`))
+			So(err, ShouldBeNil)
+			So(ct.Time, ShouldBeNil)
+		})
+	})
 }
 
 func TestGetPacketType(t *testing.T) {

--- a/internal/gateway/structs_test.go
+++ b/internal/gateway/structs_test.go
@@ -64,7 +64,8 @@ func TestCompactTime(t *testing.T) {
 
 		Convey("MarshalJSON returns '\"2006-01-02T22:04:05Z\"'", func() {
 
-			b, err := CompactTime(ts).MarshalJSON()
+			ct := CompactTime{&ts}
+			b, err := ct.MarshalJSON()
 			So(err, ShouldBeNil)
 			So(string(b), ShouldEqual, `"2006-01-02T22:04:05Z"`)
 		})
@@ -75,7 +76,7 @@ func TestCompactTime(t *testing.T) {
 				var ct CompactTime
 				err := ct.UnmarshalJSON([]byte(s))
 				So(err, ShouldBeNil)
-				So(time.Time(ct).Equal(ts), ShouldBeTrue)
+				So(ct.Time.Equal(ts), ShouldBeTrue)
 			})
 		})
 	})

--- a/internal/gateway/structs_test.go
+++ b/internal/gateway/structs_test.go
@@ -80,22 +80,6 @@ func TestCompactTime(t *testing.T) {
 			})
 		})
 	})
-
-	Convey("Given an empty string as date value", t, func() {
-		Convey("MarshalJSON returns null", func() {
-			ct := CompactTime{nil}
-			b, err := ct.MarshalJSON()
-			So(err, ShouldBeNil)
-			So(string(b), ShouldEqual, "null")
-		})
-
-		Convey("UnmarshalJSON returns nil", func() {
-			var ct CompactTime
-			err := ct.UnmarshalJSON([]byte(`""`))
-			So(err, ShouldBeNil)
-			So(ct.Time, ShouldBeNil)
-		})
-	})
 }
 
 func TestGetPacketType(t *testing.T) {

--- a/internal/gateway/structs_test.go
+++ b/internal/gateway/structs_test.go
@@ -79,6 +79,22 @@ func TestCompactTime(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given an empty string as date value", t, func() {
+		Convey("UnmarshalJSON returns nil", func() {
+			var ct CompactTime
+			err := ct.UnmarshalJSON([]byte(`""`))
+			So(err, ShouldBeNil)
+			So(time.Time(ct).Equal(time.Time{}), ShouldBeTrue)
+		})
+
+		Convey("MarshalJSON returns null", func() {
+			ct := CompactTime(time.Time{})
+			b, err := ct.MarshalJSON()
+			So(err, ShouldBeNil)
+			So(string(b), ShouldEqual, "null")
+		})
+	})
 }
 
 func TestGetPacketType(t *testing.T) {


### PR DESCRIPTION
Some vendor's (e.g. gemtek) gateway sends an empty string value as `time` property of Rx packet (an empty string means "ignore me", this is terrible...)
In the current implementation, the gateway-bridge raises errors at [here](https://github.com/brocaar/lora-gateway-bridge/blob/359742accabc2c5c3e9cd6987cb21f7597330f3e/internal/gateway/structs.go#L324) when an empty `time` has come so it cannot receive any packets if `time` is an empty string.

This pull-request cares this problem.