### PR TITLE
Make `maximum seconds that will be waited between reconnection attempts when connection is lost` to be configurable

### DIFF
--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -130,8 +130,9 @@ tls_cert="{{ .Backend.MQTT.TLSCert }}"
 # mqtt TLS key file (optional)
 tls_key="{{ .Backend.MQTT.TLSKey }}"
 
-# maximum seconds that will be waited between reconnection attempts when connection is lost
-max_reconnect_interval_seconds="{{ .Backend.MQTT.MaxReconnectIntervalSeconds }}"
+# Maximum interval that will be waited between reconnection attempts when connection is lost.
+# Valid units are 'ms', 's', 'm', 'h'. Note that these values can be combined, e.g. '24h30m15s'.
+max_reconnect_interval="{{ .Backend.MQTT.MaxReconnectInterval }}"
 `
 
 var configCmd = &cobra.Command{

--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -129,6 +129,9 @@ tls_cert="{{ .Backend.MQTT.TLSCert }}"
 
 # mqtt TLS key file (optional)
 tls_key="{{ .Backend.MQTT.TLSKey }}"
+
+# maximum seconds that will be waited between reconnection attempts when connection is lost
+max_reconnect_interval_seconds="{{ .Backend.MQTT.MaxReconnectIntervalSeconds }}"
 `
 
 var configCmd = &cobra.Command{

--- a/cmd/lora-gateway-bridge/cmd/root.go
+++ b/cmd/lora-gateway-bridge/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io/ioutil"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -79,7 +80,7 @@ func init() {
 	viper.SetDefault("backend.mqtt.config_topic_template", "gateway/{{ .MAC }}/config")
 	viper.SetDefault("backend.mqtt.server", "tcp://127.0.0.1:1883")
 	viper.SetDefault("backend.mqtt.clean_session", true)
-	viper.SetDefault("backend.mqtt.max_reconnect_interval", "") // if this value is empty, it will be used default value
+	viper.SetDefault("backend.mqtt.max_reconnect_interval", 10*time.Minute)
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)

--- a/cmd/lora-gateway-bridge/cmd/root.go
+++ b/cmd/lora-gateway-bridge/cmd/root.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"time"
-
 	"github.com/brocaar/lora-gateway-bridge/internal/config"
 )
 
@@ -81,7 +79,7 @@ func init() {
 	viper.SetDefault("backend.mqtt.config_topic_template", "gateway/{{ .MAC }}/config")
 	viper.SetDefault("backend.mqtt.server", "tcp://127.0.0.1:1883")
 	viper.SetDefault("backend.mqtt.clean_session", true)
-	viper.SetDefault("backend.mqtt.max_reconnect_interval_seconds", 10*time.Minute)
+	viper.SetDefault("backend.mqtt.max_reconnect_interval", "") // if this value is empty, it will be used default value
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)

--- a/cmd/lora-gateway-bridge/cmd/root.go
+++ b/cmd/lora-gateway-bridge/cmd/root.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"time"
+
 	"github.com/brocaar/lora-gateway-bridge/internal/config"
 )
 
@@ -79,6 +81,7 @@ func init() {
 	viper.SetDefault("backend.mqtt.config_topic_template", "gateway/{{ .MAC }}/config")
 	viper.SetDefault("backend.mqtt.server", "tcp://127.0.0.1:1883")
 	viper.SetDefault("backend.mqtt.clean_session", true)
+	viper.SetDefault("backend.mqtt.max_reconnect_interval_seconds", 10*time.Minute)
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -192,6 +192,9 @@ tls_cert=""
 
 # mqtt TLS key file (optional)
 tls_key=""
+
+# maximum seconds that will be waited between reconnection attempts when connection is lost
+max_reconnect_interval_seconds=600
 ```
 
 ### Warning: deprecation warning! update your configuration

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -193,8 +193,9 @@ tls_cert=""
 # mqtt TLS key file (optional)
 tls_key=""
 
-# maximum seconds that will be waited between reconnection attempts when connection is lost
-max_reconnect_interval_seconds=600
+# Maximum interval that will be waited between reconnection attempts when connection is lost.
+# Valid units are 'ms', 's', 'm', 'h'. Note that these values can be combined, e.g. '24h30m15s'.
+max_reconnect_interval="10m"
 ```
 
 ### Warning: deprecation warning! update your configuration

--- a/internal/backend/mqttpubsub/backend.go
+++ b/internal/backend/mqttpubsub/backend.go
@@ -19,21 +19,22 @@ import (
 
 // BackendConfig holds the MQTT pub-sub backend configuration.
 type BackendConfig struct {
-	Server                string
-	Username              string
-	Password              string
-	QOS                   uint8           `mapstructure:"qos"`
-	CleanSession          bool            `mapstructure:"clean_session"`
-	ClientID              string          `mapstructure:"client_id"`
-	CACert                string          `mapstructure:"ca_cert"`
-	TLSCert               string          `mapstructure:"tls_cert"`
-	TLSKey                string          `mapstructure:"tls_key"`
-	UplinkTopicTemplate   string          `mapstructure:"uplink_topic_template"`
-	DownlinkTopicTemplate string          `mapstructure:"downlink_topic_template"`
-	StatsTopicTemplate    string          `mapstructure:"stats_topic_template"`
-	AckTopicTemplate      string          `mapstructure:"ack_topic_template"`
-	ConfigTopicTemplate   string          `mapstructure:"config_topic_template"`
-	AlwaysSubscribeMACs   []lorawan.EUI64 `mapstructure:"-"`
+	Server                      string
+	Username                    string
+	Password                    string
+	QOS                         uint8           `mapstructure:"qos"`
+	CleanSession                bool            `mapstructure:"clean_session"`
+	ClientID                    string          `mapstructure:"client_id"`
+	CACert                      string          `mapstructure:"ca_cert"`
+	TLSCert                     string          `mapstructure:"tls_cert"`
+	TLSKey                      string          `mapstructure:"tls_key"`
+	UplinkTopicTemplate         string          `mapstructure:"uplink_topic_template"`
+	DownlinkTopicTemplate       string          `mapstructure:"downlink_topic_template"`
+	StatsTopicTemplate          string          `mapstructure:"stats_topic_template"`
+	AckTopicTemplate            string          `mapstructure:"ack_topic_template"`
+	ConfigTopicTemplate         string          `mapstructure:"config_topic_template"`
+	AlwaysSubscribeMACs         []lorawan.EUI64 `mapstructure:"-"`
+	MaxReconnectIntervalSeconds time.Duration   `mapstructure:"max_reconnect_interval_seconds"`
 }
 
 // Backend implements a MQTT pub-sub backend.
@@ -100,6 +101,7 @@ func NewBackend(c BackendConfig) (*Backend, error) {
 	opts.SetClientID(b.config.ClientID)
 	opts.SetOnConnectHandler(b.onConnected)
 	opts.SetConnectionLostHandler(b.onConnectionLost)
+	opts.SetMaxReconnectInterval(b.config.MaxReconnectIntervalSeconds * time.Second)
 
 	tlsconfig, err := newTLSConfig(b.config.CACert, b.config.TLSCert, b.config.TLSKey)
 	if err != nil {

--- a/internal/backend/mqttpubsub/backend.go
+++ b/internal/backend/mqttpubsub/backend.go
@@ -34,7 +34,7 @@ type BackendConfig struct {
 	AckTopicTemplate      string          `mapstructure:"ack_topic_template"`
 	ConfigTopicTemplate   string          `mapstructure:"config_topic_template"`
 	AlwaysSubscribeMACs   []lorawan.EUI64 `mapstructure:"-"`
-	MaxReconnectInterval  string          `mapstructure:"max_reconnect_interval"`
+	MaxReconnectInterval  time.Duration   `mapstructure:"max_reconnect_interval"`
 }
 
 // Backend implements a MQTT pub-sub backend.
@@ -102,15 +102,7 @@ func NewBackend(c BackendConfig) (*Backend, error) {
 	opts.SetOnConnectHandler(b.onConnected)
 	opts.SetConnectionLostHandler(b.onConnectionLost)
 
-	maxReconnectInterval, err := time.ParseDuration(b.config.MaxReconnectInterval)
-	if err != nil {
-		if b.config.MaxReconnectInterval != "" { // empty string is passed as default value, so suppress warnings
-			log.Warnf("backend: invalid max reconnect interval is specified (given=%s)", b.config.MaxReconnectInterval)
-		}
-		const defaultMaxReconnectInterval = "10m"
-		log.Infof("backend: use default max reconnect interval: %s", defaultMaxReconnectInterval)
-		maxReconnectInterval, _ = time.ParseDuration(defaultMaxReconnectInterval)
-	}
+	maxReconnectInterval := b.config.MaxReconnectInterval
 	log.Infof("backend: set max reconnect interval: %s", maxReconnectInterval)
 	opts.SetMaxReconnectInterval(maxReconnectInterval)
 


### PR DESCRIPTION
Now the default interval is `10m` that is configured at https://github.com/eclipse/paho.mqtt.golang/blob/9ec68b7894ac4cd48fc9126e910e571d50eb5d9c/options.go#L102
This pull request makes the interval to be configurable.