### PR TITLE
Fix corrupted gateway statistics for downlink packets.

### DIFF
--- a/internal/gateway/semtech/backend_test.go
+++ b/internal/gateway/semtech/backend_test.go
@@ -219,8 +219,8 @@ func (ts *BackendTestSuite) TestPushData() {
 				ConfigVersion:       "12345",
 				RxPacketsReceived:   1,
 				RxPacketsReceivedOk: 2,
-				TxPacketsReceived:   5,
-				TxPacketsEmitted:    3,
+				TxPacketsReceived:   4,
+				TxPacketsEmitted:    5,
 			},
 		},
 		{

--- a/internal/gateway/semtech/packets/push_data.go
+++ b/internal/gateway/semtech/packets/push_data.go
@@ -54,8 +54,8 @@ func (p PushDataPacket) GetGatewayStats() (*gw.GatewayStats, error) {
 		GatewayId:           p.GatewayMAC[:],
 		RxPacketsReceived:   p.Payload.Stat.RXNb,
 		RxPacketsReceivedOk: p.Payload.Stat.RXOK,
-		TxPacketsEmitted:    p.Payload.Stat.RXFW,
-		TxPacketsReceived:   p.Payload.Stat.TXNb,
+		TxPacketsEmitted:    p.Payload.Stat.TXNb,
+		TxPacketsReceived:   p.Payload.Stat.DWNb,
 	}
 
 	// time

--- a/internal/gateway/semtech/packets/push_data_test.go
+++ b/internal/gateway/semtech/packets/push_data_test.go
@@ -96,8 +96,8 @@ func TestGetGatewayStats(t *testing.T) {
 				},
 				RxPacketsReceived:   1,
 				RxPacketsReceivedOk: 2,
-				TxPacketsReceived:   6,
-				TxPacketsEmitted:    3,
+				TxPacketsReceived:   5,
+				TxPacketsEmitted:    6,
 			},
 		},
 		{
@@ -121,8 +121,8 @@ func TestGetGatewayStats(t *testing.T) {
 				Time:                pbTime,
 				RxPacketsReceived:   1,
 				RxPacketsReceivedOk: 2,
-				TxPacketsReceived:   6,
-				TxPacketsEmitted:    3,
+				TxPacketsReceived:   5,
+				TxPacketsEmitted:    6,
 			},
 		},
 	}


### PR DESCRIPTION
There was an issue with the mapping between what's received from the Semtech Packet Forwarder over UDP and the Gateway Bridge stats.

Addresses https://forum.loraserver.io/t/rxpacketsreceived-ok-counter/2687