### PR TITLE
Fix missing MQTT QoS initialization to enable QoS 1 and 2

### DIFF
--- a/internal/backend/mqtt/backend.go
+++ b/internal/backend/mqtt/backend.go
@@ -116,6 +116,8 @@ func NewBackend(config BackendConfig) (*Backend, error) {
 		return nil, fmt.Errorf("mqtt: unknown auth type: %s", config.Auth.Type)
 	}
 
+	b.qos = config.Auth.Generic.QOS
+
 	switch config.Marshaler {
 	case "json":
 		b.marshal = func(msg proto.Message) ([]byte, error) {


### PR DESCRIPTION
Changing the QOS setting in the toml config file currently does not have any effect on the actual QoS used by the MQTT backend.
It seems that there has been a regression a while ago during a major refactoring of the architecture.

I am not sure this is the best way of fixing the issue, but it does the job. As for testing, with this fix I was able to have the gateway bridge connected with QoS 1 to AWS IoT.