### PR TITLE
fake rxInfo.Time if empty

### DIFF
--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -31,6 +31,10 @@ udp_bind = "{{ .PacketForwarder.UDPBind }}"
 # LoRa frames with CRC errors.
 skip_crc_check = {{ .PacketForwarder.SkipCRCCheck }}
 
+# Use system time when rxpk.time is empty (for gatways w/o GPS)
+# There is no other way to get the time when packet is received.
+fake_rxinfo_time = {{ .PacketForwarder.FakeRxInfoTime }}
+
 
   # # Managed packet-forwarder configuration.
   # #

--- a/cmd/lora-gateway-bridge/cmd/root.go
+++ b/cmd/lora-gateway-bridge/cmd/root.go
@@ -74,6 +74,7 @@ func init() {
 
 	// default values
 	viper.SetDefault("packet_forwarder.udp_bind", "0.0.0.0:1700")
+	viper.SetDefault("packet_forwarder.fake_rxinfo_time", false)
 
 	viper.SetDefault("backend.mqtt.uplink_topic_template", "gateway/{{ .MAC }}/rx")
 	viper.SetDefault("backend.mqtt.downlink_topic_template", "gateway/{{ .MAC }}/tx")

--- a/cmd/lora-gateway-bridge/cmd/root_run.go
+++ b/cmd/lora-gateway-bridge/cmd/root_run.go
@@ -89,7 +89,7 @@ func runV2(cmd *cobra.Command, args []string) error {
 		return pubsub.UnSubscribeGatewayTopics(mac)
 	}
 
-	gateway, err := gateway.NewBackend(config.C.PacketForwarder.UDPBind, onNew, onDelete, config.C.PacketForwarder.SkipCRCCheck, config.C.PacketForwarder.Configuration)
+	gateway, err := gateway.NewBackend(config.C.PacketForwarder.UDPBind, onNew, onDelete, config.C.PacketForwarder.SkipCRCCheck, config.C.PacketForwarder.Configuration, config.C.PacketForwarder.FakeRxInfoTime)
 	if err != nil {
 		log.Fatalf("could not setup gateway backend: %s", err)
 	}
@@ -159,7 +159,7 @@ func runV3(cmd *cobra.Command, args []string) error {
 		return backend.UnsubscribeGateway(gatewayID)
 	}
 
-	gateway, err := semtech.NewBackend(config.C.PacketForwarder.UDPBind, onNew, onDelete, config.C.PacketForwarder.Configuration)
+	gateway, err := semtech.NewBackend(config.C.PacketForwarder.UDPBind, onNew, onDelete, config.C.PacketForwarder.Configuration, config.C.PacketForwarder.FakeRxInfoTime)
 	if err != nil {
 		return errors.Wrap(err, "new gateway backend error")
 	}

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -95,6 +95,10 @@ udp_bind = "0.0.0.0:1700"
 # LoRa frames with CRC errors.
 skip_crc_check = false
 
+# Use system time when rxpk.time is empty (for gatways w/o GPS)
+# There is no other way to get the time when packet is received.
+fake_rxinfo_time = false
+
 
   # # Managed packet-forwarder configuration.
   # #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	PacketForwarder struct {
 		UDPBind      string `mapstructure:"udp_bind"`
 		SkipCRCCheck bool   `mapstructure:"skip_crc_check"`
+		FakeRxInfoTime bool `mapstructure:"fake_rxinfo_time"`
 
 		Configuration []semtech.PFConfiguration `mapstructure:"configuration"`
 	} `mapstructure:"packet_forwarder"`

--- a/internal/gateway/semtech/backend.go
+++ b/internal/gateway/semtech/backend.go
@@ -47,10 +47,11 @@ type Backend struct {
 	closed         bool
 	gateways       gateways
 	configurations []PFConfiguration
+	FakeRxInfoTime bool
 }
 
 // NewBackend creates a new backend.
-func NewBackend(bind string, onNew, onDelete func(lorawan.EUI64) error, configurations []PFConfiguration) (*Backend, error) {
+func NewBackend(bind string, onNew, onDelete func(lorawan.EUI64) error, configurations []PFConfiguration, FakeRxInfoTime bool) (*Backend, error) {
 	addr, err := net.ResolveUDPAddr("udp", bind)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolve udp addr error")
@@ -74,6 +75,7 @@ func NewBackend(bind string, onNew, onDelete func(lorawan.EUI64) error, configur
 			onDelete: onDelete,
 		},
 		configurations: configurations,
+		FakeRxInfoTime: FakeRxInfoTime,
 	}
 
 	go func() {
@@ -435,7 +437,7 @@ func (b *Backend) handlePushData(up udpPacket) error {
 	}
 
 	// uplink frames
-	uplinkFrames, err := p.GetUplinkFrames()
+	uplinkFrames, err := p.GetUplinkFrames(b.FakeRxInfoTime)
 	if err != nil {
 		return errors.Wrap(err, "get uplink frames error")
 	}

--- a/internal/gateway/semtech/backend_test.go
+++ b/internal/gateway/semtech/backend_test.go
@@ -50,7 +50,7 @@ func (ts *BackendTestSuite) SetupTest() {
 			RestartCommand: "touch " + filepath.Join(ts.tempDir, "restart"),
 			Version:        "12345",
 		},
-	})
+	},false)
 	assert.NoError(err)
 
 	ts.backendUDPAddr, err = net.ResolveUDPAddr("udp", ts.backend.conn.LocalAddr().String())

--- a/internal/gateway/semtech/packets/push_data.go
+++ b/internal/gateway/semtech/packets/push_data.go
@@ -148,7 +148,7 @@ func getUplinkFrame(gatewayID []byte, rxpk RXPK, FakeRxInfoTime bool) (gw.Uplink
 		}
 		frame.RxInfo.Time = ts
 	} else if FakeRxInfoTime {
-		ts, _ := ptypes.TimestampProto(CompactTime(time.Now().UTC()))
+		ts, _ := ptypes.TimestampProto(time.Now().UTC())
 		frame.RxInfo.Time = ts
 	}
 

--- a/internal/gateway/semtech/packets/push_data.go
+++ b/internal/gateway/semtech/packets/push_data.go
@@ -79,19 +79,19 @@ func (p PushDataPacket) GetGatewayStats() (*gw.GatewayStats, error) {
 }
 
 // GetUplinkFrames returns a slice of gw.UplinkFrame.
-func (p PushDataPacket) GetUplinkFrames() ([]gw.UplinkFrame, error) {
+func (p PushDataPacket) GetUplinkFrames(FakeRxInfoTime bool) ([]gw.UplinkFrame, error) {
 	var frames []gw.UplinkFrame
 
 	for i := range p.Payload.RXPK {
 		if len(p.Payload.RXPK[i].RSig) == 0 {
-			frame, err := getUplinkFrame(p.GatewayMAC[:], p.Payload.RXPK[i])
+			frame, err := getUplinkFrame(p.GatewayMAC[:], p.Payload.RXPK[i], FakeRxInfoTime)
 			if err != nil {
 				return nil, errors.Wrap(err, "gateway: get uplink frame error")
 			}
 			frames = append(frames, frame)
 		} else {
 			for j := range p.Payload.RXPK[i].RSig {
-				frame, err := getUplinkFrame(p.GatewayMAC[:], p.Payload.RXPK[i])
+				frame, err := getUplinkFrame(p.GatewayMAC[:], p.Payload.RXPK[i], FakeRxInfoTime)
 				if err != nil {
 					return nil, errors.Wrap(err, "gateway: get uplink frame error")
 				}
@@ -123,7 +123,7 @@ func setUplinkFrameRSig(frame gw.UplinkFrame, rxPK RXPK, rSig RSig) gw.UplinkFra
 	return frame
 }
 
-func getUplinkFrame(gatewayID []byte, rxpk RXPK) (gw.UplinkFrame, error) {
+func getUplinkFrame(gatewayID []byte, rxpk RXPK, FakeRxInfoTime bool) (gw.UplinkFrame, error) {
 	frame := gw.UplinkFrame{
 		PhyPayload: rxpk.Data,
 		TxInfo: &gw.UplinkTXInfo{
@@ -146,6 +146,9 @@ func getUplinkFrame(gatewayID []byte, rxpk RXPK) (gw.UplinkFrame, error) {
 		if err != nil {
 			return frame, errors.Wrap(err, "gateway: timestamp proto error")
 		}
+		frame.RxInfo.Time = ts
+	} else if FakeRxInfoTime {
+		ts, _ := ptypes.TimestampProto(CompactTime(time.Now().UTC()))
 		frame.RxInfo.Time = ts
 	}
 

--- a/internal/gateway/semtech/packets/push_data_test.go
+++ b/internal/gateway/semtech/packets/push_data_test.go
@@ -320,7 +320,7 @@ func TestGetUplinkFrame(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		f, err := test.PushDataPacket.GetUplinkFrames()
+		f, err := test.PushDataPacket.GetUplinkFrames(false)
 		assert.Nil(err)
 		assert.Equal(test.UplinkFrames, f)
 	}

--- a/internal/legacy/gateway/backend.go
+++ b/internal/legacy/gateway/backend.go
@@ -107,10 +107,11 @@ type Backend struct {
 	configurations []semtech.PFConfiguration
 	wg             sync.WaitGroup
 	skipCRCCheck   bool
+	FakeRxInfoTime bool
 }
 
 // NewBackend creates a new backend.
-func NewBackend(bind string, onNew func(lorawan.EUI64) error, onDelete func(lorawan.EUI64) error, skipCRCCheck bool, configurations []semtech.PFConfiguration) (*Backend, error) {
+func NewBackend(bind string, onNew func(lorawan.EUI64) error, onDelete func(lorawan.EUI64) error, skipCRCCheck bool, configurations []semtech.PFConfiguration, FakeRxInfoTime bool) (*Backend, error) {
 	addr, err := net.ResolveUDPAddr("udp", bind)
 	if err != nil {
 		return nil, err
@@ -134,6 +135,7 @@ func NewBackend(bind string, onNew func(lorawan.EUI64) error, onDelete func(lora
 			onDelete: onDelete,
 		},
 		configurations: configurations,
+		FakeRxInfoTime: FakeRxInfoTime,
 	}
 
 	go func() {
@@ -465,7 +467,7 @@ func (b *Backend) handleRXPacket(addr *net.UDPAddr, mac lorawan.EUI64, rxpk RXPK
 	log.WithFields(logFields).Info("gateway: rxpk packet received")
 
 	// decode packet(s)
-	rxPackets, err := newRXPacketsFromRXPK(mac, rxpk)
+	rxPackets, err := newRXPacketsFromRXPK(mac, rxpk, b.FakeRxInfoTime)
 	if err != nil {
 		return err
 	}

--- a/internal/legacy/gateway/backend_test.go
+++ b/internal/legacy/gateway/backend_test.go
@@ -32,7 +32,7 @@ func TestBackend(t *testing.T) {
 				RestartCommand: "touch " + filepath.Join(tempDir, "restart"),
 				Version:        "12345",
 			},
-		})
+		},false)
 		So(err, ShouldBeNil)
 
 		backendAddr, err := net.ResolveUDPAddr("udp", backend.conn.LocalAddr().String())

--- a/internal/legacy/gateway/backend_test.go
+++ b/internal/legacy/gateway/backend_test.go
@@ -228,7 +228,7 @@ func TestBackend(t *testing.T) {
 					Convey("Then the packet is returned by the RX packet channel", func() {
 						rxPacket := <-backend.RXPacketChan()
 
-						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0])
+						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0], false)
 						So(err, ShouldBeNil)
 						So(rxPacket, ShouldResemble, rxPackets[0])
 					})
@@ -326,7 +326,7 @@ func TestBackend(t *testing.T) {
 					Convey("Then the packet is returned by the RX packet channel", func() {
 						rxPacket := <-backend.RXPacketChan()
 
-						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0])
+						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0], false)
 						So(err, ShouldBeNil)
 						So(rxPacket, ShouldResemble, rxPackets[0])
 					})
@@ -374,7 +374,7 @@ func TestBackend(t *testing.T) {
 					Convey("Then the packet is returned by the RX packet channel", func() {
 						rxPacket := <-backend.RXPacketChan()
 
-						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0])
+						rxPackets, err := newRXPacketsFromRXPK(p.GatewayMAC, p.Payload.RXPK[0], false)
 						So(err, ShouldBeNil)
 						So(rxPacket, ShouldResemble, rxPackets[0])
 					})

--- a/internal/legacy/gateway/pf_structs.go
+++ b/internal/legacy/gateway/pf_structs.go
@@ -525,7 +525,7 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK, FakeRxInfoTime bool) ([]
 			rxPacket.RXInfo.Time = &ts
 		}
 	} else if FakeRxInfoTime {
-		ts, _ := ptypes.TimestampProto(CompactTime(time.Now().UTC()))
+		ts, _ := ptypes.TimestampProto(time.Now().UTC())
 		frame.RxInfo.Time = ts
 	}
 

--- a/internal/legacy/gateway/pf_structs.go
+++ b/internal/legacy/gateway/pf_structs.go
@@ -525,8 +525,8 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK, FakeRxInfoTime bool) ([]
 			rxPacket.RXInfo.Time = &ts
 		}
 	} else if FakeRxInfoTime {
-		ts, _ := ptypes.TimestampProto(time.Now().UTC())
-		frame.RxInfo.Time = ts
+		ts := time.Now().UTC()
+		rxPacket.RXInfo.Time = &ts
 	}
 
 	if rxpk.Tmms != nil {

--- a/internal/legacy/gateway/pf_structs.go
+++ b/internal/legacy/gateway/pf_structs.go
@@ -379,12 +379,13 @@ func (d DatR) MarshalJSON() ([]byte, error) {
 func (d *DatR) UnmarshalJSON(data []byte) error {
 	i, err := strconv.ParseUint(string(data), 10, 32)
 	if err != nil {
-		d.LoRa = strings.Trim(string(data), `"`)
+		d.LoRa = strings.Trim(string(data), `"`) //"
 		return nil
 	}
 	d.FSK = uint32(i)
 	return nil
 }
+
 
 // RXPK contain a RF packet and associated metadata.
 type RXPK struct {
@@ -487,7 +488,7 @@ func newGatewayStatsPacket(mac lorawan.EUI64, stat Stat) gw.GatewayStatsPacket {
 
 // newRXPacketsFromRXPK transforms a Semtech packet into a slice of
 // gw.RXPacketBytes.
-func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, error) {
+func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK, FakeRxInfoTime bool) ([]gw.RXPacketBytes, error) {
 	dataRate, err := newDataRateFromDatR(rxpk.DatR)
 	if err != nil {
 		return nil, fmt.Errorf("gateway: could not get DataRate from DatR: %s", err)
@@ -523,6 +524,9 @@ func newRXPacketsFromRXPK(mac lorawan.EUI64, rxpk RXPK) ([]gw.RXPacketBytes, err
 		if !ts.IsZero() {
 			rxPacket.RXInfo.Time = &ts
 		}
+	} else if FakeRxInfoTime {
+		ts, _ := ptypes.TimestampProto(CompactTime(time.Now().UTC()))
+		frame.RxInfo.Time = ts
 	}
 
 	if rxpk.Tmms != nil {

--- a/internal/legacy/gateway/pf_structs_test.go
+++ b/internal/legacy/gateway/pf_structs_test.go
@@ -546,7 +546,7 @@ func TestNewRXPacketFromRXPK(t *testing.T) {
 		mac := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 
 		Convey("When calling newRXPacketsFromRXPK without RSig field", func() {
-			rxPackets, err := newRXPacketsFromRXPK(mac, rxpk)
+			rxPackets, err := newRXPacketsFromRXPK(mac, rxpk, false)
 			So(err, ShouldBeNil)
 			So(rxPackets, ShouldHaveLength, 1)
 
@@ -591,7 +591,7 @@ func TestNewRXPacketFromRXPK(t *testing.T) {
 					RSSIC: -30,
 				},
 			}
-			rxPackets, err := newRXPacketsFromRXPK(mac, rxpk)
+			rxPackets, err := newRXPacketsFromRXPK(mac, rxpk, false)
 			So(err, ShouldBeNil)
 			So(rxPackets, ShouldHaveLength, 2)
 


### PR DESCRIPTION
The Semtech packet-forwarder does not fill up the time and tmms fields if the gateway has no GPS.

Does nobody want to get a receive-time ?

This patch is for setting the time from system-time if it is empty.
A configuration flag is included to control behavior.
Should work on V2 + V3.

Something wrong ?