### PR TITLE
Azure IoT Hub Support

### DIFF
--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -191,6 +191,24 @@ marshaler="{{ .Backend.MQTT.Marshaler }}"
     # public-key.pem with this device / gateway in Google Cloud IoT Core.
     jwt_key_file="{{ .Backend.MQTT.Auth.GCPCloudIoTCore.JWTKeyFile }}"
 
+    # Azure IoT Hub
+    #
+    # This setting will preset uplink and downlink topics that will only
+    # work with Azure IoT Hub service.
+    [backend.mqtt.auth.azure_iot_hub]
+
+    # Azure IoT Device Id
+    device_id=""
+
+    # Azure IoT Hub name
+    iot_hub_name=""
+
+    # Azure IoT Hub CA cert
+    iot_hub_ca_file=""
+
+    # Azure IoT Device Key
+    device_key_file=""
+
 
 # Metrics configuration.
 [metrics]

--- a/cmd/lora-gateway-bridge/cmd/configfile.go
+++ b/cmd/lora-gateway-bridge/cmd/configfile.go
@@ -198,16 +198,16 @@ marshaler="{{ .Backend.MQTT.Marshaler }}"
     [backend.mqtt.auth.azure_iot_hub]
 
     # Azure IoT Device Id
-    device_id=""
+    device_id="{{ .Backend.MQTT.Auth.AzureIoTHub.DeviceID }}"
 
     # Azure IoT Hub name
-    iot_hub_name=""
+    iot_hub_name="{{ .Backend.MQTT.Auth.AzureIoTHub.IOTHubName }}"
 
     # Azure IoT Hub CA cert
-    iot_hub_ca_file=""
+    iot_hub_ca_file="{{ .Backend.MQTT.Auth.AzureIoTHub.IOTHubCAFile }}"
 
     # Azure IoT Device Key
-    device_key_file=""
+    device_key_file="{{ .Backend.MQTT.Auth.AzureIoTHub.DeviceKeyFile }}"
 
 
 # Metrics configuration.

--- a/internal/backend/mqtt/auth/azure_iot_hub.go
+++ b/internal/backend/mqtt/auth/azure_iot_hub.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	b64 "encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"strconv"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/pkg/errors"
+)
+
+type AzureIoTHubConfig struct {
+	DeviceID      string `mapstructure:"device_id"`
+	IOTHubname    string `mapstructure:"iot_hub_name"`
+	CACert        string `mapstructure:"iot_hub_ca_file"`
+	DeviceKeyFile string `mapstructure:"device_key_file"`
+}
+
+type AzureIoTHubAuthentication struct {
+	clientID  string
+	username  string
+	password  string
+	tlsConfig *tls.Config
+	config    AzureIoTHubConfig
+}
+
+func createSASToken(uri string, saKey []byte) string {
+	encoded := url.QueryEscape(uri)
+	now := time.Now().Unix()
+	day := 60 * 60 * 24
+	ts := now + int64(day)
+	expiry := strconv.Itoa(int(ts))
+	signature := encoded + "\n" + expiry
+	b64key, err := b64.StdEncoding.DecodeString(string(saKey))
+	if err != nil {
+		log.Panicf("Azure IoT Key cannot be decoded")
+	}
+
+	mac := hmac.New(sha256.New, b64key)
+	mac.Write([]byte(signature))
+	hash := url.QueryEscape(b64.StdEncoding.EncodeToString(mac.Sum(nil)))
+
+	// IoT Hub SAS Token only needs `sr`, `sig` and `se` unlike other Azure servies
+	token := fmt.Sprintf("SharedAccessSignature sr=%s&sig=%s&se=%s",
+		encoded,
+		hash,
+		expiry,
+	)
+
+	return token
+}
+
+func NewAzureIoTHubAuthentication(config AzureIoTHubConfig) (Authentication, error) {
+	tlsConfig, err := newTLSConfig(config.CACert, "", "")
+	if err != nil {
+		return nil, errors.Wrap(err, "read ca cert")
+	}
+
+	deviceKey, err := ioutil.ReadFile(config.DeviceKeyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading device key file")
+	}
+
+	username := fmt.Sprintf("%s.azure-devices.net/%s",
+		config.IOTHubname,
+		config.DeviceID,
+	)
+
+	resourceUri := fmt.Sprintf("%s.azure-devices.net/devices/%s",
+		config.IOTHubname,
+		config.DeviceID,
+	)
+
+	token := createSASToken(resourceUri, deviceKey)
+
+	return &AzureIoTHubAuthentication{
+		clientID:  config.DeviceID,
+		username:  username,
+		password:  token,
+		tlsConfig: tlsConfig,
+		config:    config,
+	}, nil
+}
+
+func (a *AzureIoTHubAuthentication) Init(opts *mqtt.ClientOptions) error {
+	broker := fmt.Sprintf("ssl://%s.azure-devices.net:8883", a.config.IOTHubname)
+	opts.AddBroker(broker)
+	opts.SetClientID(a.clientID)
+	opts.SetUsername(a.username)
+	opts.SetPassword(a.password)
+
+	return nil
+}
+
+func (a *AzureIoTHubAuthentication) Update(opts *mqtt.ClientOptions) error {
+	return nil
+}
+
+func (a *AzureIoTHubAuthentication) ReconnectAfter() time.Duration {
+	return 24 * time.Hour
+}

--- a/internal/backend/mqtt/auth/azure_iot_hub.go
+++ b/internal/backend/mqtt/auth/azure_iot_hub.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/eclipse/paho.mqtt.golang"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
The following PR adds Azure IoT Hub as a backend for the bridge. The Loraserver component that subscribes/publishes to the Hub will utilize Azure Event Hubs. 