### PR TITLE
fix bandwidth for SX1301ConfChanLoRaStd in basicstation router-config

### DIFF
--- a/internal/backend/basicstation/structs/router_config.go
+++ b/internal/backend/basicstation/structs/router_config.go
@@ -166,7 +166,7 @@ func GetRouterConfig(region band.Name, netIDs []lorawan.NetID, joinEUIs [][2]lor
 					Enable:          true,
 					Radio:           r,
 					IF:              int(channel.Frequency) - int(radioFrequencies[r]),
-					Bandwidth:       modInfo.Bandwidth,
+					Bandwidth:       modInfo.Bandwidth * 1000,
 					SpreadingFactor: modInfo.SpreadingFactors[0],
 				}
 


### PR DESCRIPTION
BasicStation expects the bandwidth value for the ChanLoRaStd to be specified in Hz, rather than kHz. This is in the same format as the SX1301 section in the old LoRa Packet Forwarder config files.

Multiply the given value by 1000 in order to meet this requirement.